### PR TITLE
Initial Phoenix/React job feed scaffold

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+setup:
+	cd backend && mix deps.get
+	cd frontend && npm install
+	cd backend && mix ecto.create && mix ecto.migrate
+
+db.reset:
+	cd backend && mix ecto.drop && mix ecto.create && mix ecto.migrate
+
+dev:
+	cd backend && mix phx.server
+
+test:
+	cd backend && mix test
+	cd frontend && npm test -- --run
+
+fly.deploy:
+	fly deploy

--- a/backend/apps/api/lib/dashboard/application.ex
+++ b/backend/apps/api/lib/dashboard/application.ex
@@ -1,0 +1,20 @@
+defmodule Dashboard.Application do
+  use Application
+
+  def start(_type, _args) do
+    children = [
+      Dashboard.Repo,
+      {Finch, name: Dashboard.Finch},
+      {Oban, Application.fetch_env!(:api, Oban)},
+      DashboardWeb.Endpoint
+    ]
+
+    opts = [strategy: :one_for_one, name: Dashboard.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+
+  def config_change(changed, _new, removed) do
+    DashboardWeb.Endpoint.config_change(changed, removed)
+    :ok
+  end
+end

--- a/backend/apps/api/lib/dashboard/jobs/context.ex
+++ b/backend/apps/api/lib/dashboard/jobs/context.ex
@@ -1,0 +1,33 @@
+defmodule Dashboard.Jobs do
+  alias Dashboard.{Repo, Jobs}
+  import Ecto.Query
+  alias Dashboard.Jobs.{JobPosting, JobCondition, Provider}
+
+  def list_conditions do
+    Repo.all(JobCondition)
+  end
+
+  def list_postings(condition_id) do
+    Repo.all(from p in JobPosting, where: p.condition_id == ^condition_id)
+  end
+
+  def fetch_and_insert(keyword) do
+    provider().fetch(keyword)
+    |> Enum.map(fn attrs ->
+      %JobPosting{}
+      |> JobPosting.changeset(Map.put(attrs, :condition_id, keyword))
+      |> Repo.insert(on_conflict: :nothing)
+      |> case do
+        {:error, _} -> nil
+        {:ok, posting} ->
+          Absinthe.Subscription.publish(DashboardWeb.Endpoint, posting,
+            job_posting_added: posting.condition_id)
+          posting
+      end
+    end)
+  end
+
+  defp provider do
+    Application.get_env(:dashboard, :provider, Dashboard.Jobs.Providers.GitHub)
+  end
+end

--- a/backend/apps/api/lib/dashboard/jobs/cron.ex
+++ b/backend/apps/api/lib/dashboard/jobs/cron.ex
@@ -1,0 +1,12 @@
+defmodule Dashboard.Jobs.Cron do
+  use Oban.Worker, queue: :default
+  alias Dashboard.Jobs
+
+  @impl Oban.Worker
+  def perform(_job) do
+    for %{keyword: kw} <- Jobs.list_conditions() do
+      Jobs.fetch_and_insert(kw)
+    end
+    :ok
+  end
+end

--- a/backend/apps/api/lib/dashboard/jobs/job_condition.ex
+++ b/backend/apps/api/lib/dashboard/jobs/job_condition.ex
@@ -1,0 +1,16 @@
+defmodule Dashboard.Jobs.JobCondition do
+  use Ecto.Schema
+  import Ecto.Changeset
+  @primary_key {:id, :binary_id, autogenerate: true}
+
+  schema "job_conditions" do
+    field :keyword, :string
+    timestamps()
+  end
+
+  def changeset(struct, params) do
+    struct
+    |> cast(params, [:keyword])
+    |> validate_required([:keyword])
+  end
+end

--- a/backend/apps/api/lib/dashboard/jobs/job_posting.ex
+++ b/backend/apps/api/lib/dashboard/jobs/job_posting.ex
@@ -1,0 +1,19 @@
+defmodule Dashboard.Jobs.JobPosting do
+  use Ecto.Schema
+  import Ecto.Changeset
+  @primary_key {:id, :binary_id, autogenerate: true}
+
+  schema "job_postings" do
+    field :title, :string
+    field :company, :string
+    field :url, :string
+    belongs_to :condition, Dashboard.Jobs.JobCondition, type: :binary_id
+    timestamps()
+  end
+
+  def changeset(struct, params) do
+    struct
+    |> cast(params, [:title, :company, :url, :condition_id])
+    |> validate_required([:title, :url, :condition_id])
+  end
+end

--- a/backend/apps/api/lib/dashboard/jobs/provider.ex
+++ b/backend/apps/api/lib/dashboard/jobs/provider.ex
@@ -1,0 +1,3 @@
+defmodule Dashboard.Jobs.Provider do
+  @callback fetch(String.t()) :: [%{title: String.t(), company: String.t(), url: String.t()}]
+end

--- a/backend/apps/api/lib/dashboard/jobs/providers/github.ex
+++ b/backend/apps/api/lib/dashboard/jobs/providers/github.ex
@@ -1,0 +1,20 @@
+defmodule Dashboard.Jobs.Providers.GitHub do
+  @behaviour Dashboard.Jobs.Provider
+  require Logger
+
+  @endpoint Application.compile_env(:dashboard, :github_jobs_endpoint, "https://ghjobs.io/api/v1/jobs")
+
+  def fetch(keyword) do
+    url = "#{@endpoint}?search=#{URI.encode(keyword)}"
+    case Finch.build(:get, url) |> Finch.request(Dashboard.Finch) do
+      {:ok, %Finch.Response{status: 200, body: body}} ->
+        Jason.decode!(body)
+      {:ok, %Finch.Response{status: status}} ->
+        Logger.error("GitHub provider status: #{status}")
+        []
+      {:error, reason} ->
+        Logger.error("GitHub provider error: #{inspect(reason)}")
+        []
+    end
+  end
+end

--- a/backend/apps/api/lib/dashboard/repo.ex
+++ b/backend/apps/api/lib/dashboard/repo.ex
@@ -1,0 +1,5 @@
+defmodule Dashboard.Repo do
+  use Ecto.Repo,
+    otp_app: :api,
+    adapter: Ecto.Adapters.Postgres
+end

--- a/backend/apps/api/lib/dashboard_web.ex
+++ b/backend/apps/api/lib/dashboard_web.ex
@@ -1,0 +1,52 @@
+defmodule DashboardWeb do
+  def controller do
+    quote do
+      use Phoenix.Controller, namespace: DashboardWeb
+      import Plug.Conn
+      import DashboardWeb.Gettext
+    end
+  end
+
+  def router do
+    quote do
+      use Phoenix.Router
+      import Phoenix.Controller
+    end
+  end
+
+  def channel do
+    quote do
+      use Phoenix.Channel
+    end
+  end
+
+  def view do
+    quote do
+      use Phoenix.View,
+        root: "lib/dashboard_web/templates",
+        namespace: DashboardWeb
+
+      import Phoenix.Controller,
+        only: [get_flash: 1, get_flash: 2, view_module: 1, view_template: 1]
+      unquote(html_helpers())
+    end
+  end
+
+  defp html_helpers do
+    quote do
+      import Phoenix.HTML
+      import Phoenix.View
+      alias DashboardWeb.Router.Helpers, as: Routes
+    end
+  end
+
+  def gettext do
+    quote do
+      import DashboardWeb.Gettext
+    end
+  end
+
+  defmacro __using__(which) when is_atom(which) do
+    apply(__MODULE__, which, [])
+  end
+end

--- a/backend/apps/api/lib/dashboard_web/endpoint.ex
+++ b/backend/apps/api/lib/dashboard_web/endpoint.ex
@@ -1,0 +1,22 @@
+defmodule DashboardWeb.Endpoint do
+  use Phoenix.Endpoint, otp_app: :api
+
+  socket "/socket", Absinthe.Phoenix.Socket, websocket: [subprotocols: ["graphql-ws"]]
+
+  plug Plug.Static,
+    at: "/",
+    from: :api,
+    gzip: false,
+    only: ~w()
+
+  plug Plug.RequestId
+  plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
+  plug Plug.Parsers,
+    parsers: [:urlencoded, :multipart, :json],
+    pass: ["*/*"],
+    json_decoder: Phoenix.json_library()
+  plug Plug.MethodOverride
+  plug Plug.Head
+
+  plug DashboardWeb.Router
+end

--- a/backend/apps/api/lib/dashboard_web/gettext.ex
+++ b/backend/apps/api/lib/dashboard_web/gettext.ex
@@ -1,0 +1,3 @@
+defmodule DashboardWeb.Gettext do
+  use Gettext, otp_app: :api
+end

--- a/backend/apps/api/lib/dashboard_web/router.ex
+++ b/backend/apps/api/lib/dashboard_web/router.ex
@@ -1,0 +1,15 @@
+defmodule DashboardWeb.Router do
+  use DashboardWeb, :router
+
+  pipeline :api do
+    plug :accepts, ["json"]
+  end
+
+  scope "/api" do
+    pipe_through :api
+    forward "/graphql", Absinthe.Plug, schema: DashboardWeb.Schema
+    if Mix.env() == :dev do
+      forward "/graphiql", Absinthe.Plug.GraphiQL, schema: DashboardWeb.Schema
+    end
+  end
+end

--- a/backend/apps/api/lib/dashboard_web/schema.ex
+++ b/backend/apps/api/lib/dashboard_web/schema.ex
@@ -1,0 +1,31 @@
+defmodule DashboardWeb.Schema do
+  use Absinthe.Schema
+  alias Dashboard.Jobs
+
+  object :job_posting do
+    field :id, non_null(:id)
+    field :title, :string
+    field :company, :string
+    field :url, :string
+    field :condition_id, :id
+    field :inserted_at, :naive_datetime
+  end
+
+  query do
+    field :job_postings, list_of(:job_posting) do
+      arg :condition_id, non_null(:id)
+      resolve fn %{condition_id: id}, _ ->
+        {:ok, Jobs.list_postings(id)}
+      end
+    end
+  end
+
+  subscription do
+    field :job_posting_added, :job_posting do
+      arg :condition_id, non_null(:id)
+      config fn args, _ ->
+        {:ok, topic: args.condition_id}
+      end
+    end
+  end
+end

--- a/backend/apps/api/mix.exs
+++ b/backend/apps/api/mix.exs
@@ -1,0 +1,42 @@
+defmodule Api.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :api,
+      version: "0.1.0",
+      build_path: "../../_build",
+      config_path: "../../config/config.exs",
+      deps_path: "../../deps",
+      lockfile: "../../mix.lock",
+      elixir: "~> 1.15",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      mod: {Dashboard.Application, []},
+      extra_applications: [:logger, :runtime_tools]
+    ]
+  end
+
+  defp deps do
+    [
+      {:phoenix, "~> 1.7.10"},
+      {:phoenix_pubsub, "~> 2.1"},
+      {:phoenix_ecto, "~> 4.4"},
+      {:ecto_sql, "~> 3.10"},
+      {:postgrex, ">= 0.0.0"},
+      {:absinthe, "~> 1.7"},
+      {:absinthe_plug, "~> 1.7"},
+      {:oban, "~> 2.17"},
+      {:finch, "~> 0.16"},
+      {:jason, "~> 1.4"},
+      {:plug_cowboy, "~> 2.5"},
+      {:mox, "~> 1.0", only: :test},
+      {:floki, "~> 0.35", only: :test}
+    ]
+  end
+end

--- a/backend/apps/api/priv/repo/migrations/20240101000000_create_job_conditions.exs
+++ b/backend/apps/api/priv/repo/migrations/20240101000000_create_job_conditions.exs
@@ -1,0 +1,13 @@
+defmodule Dashboard.Repo.Migrations.CreateJobConditions do
+  use Ecto.Migration
+
+  def change do
+    create table(:job_conditions, primary_key: false) do
+      add :id, :uuid, primary_key: true
+      add :keyword, :string, null: false
+      timestamps()
+    end
+
+    create unique_index(:job_conditions, [:keyword])
+  end
+end

--- a/backend/apps/api/priv/repo/migrations/20240101000001_create_job_postings.exs
+++ b/backend/apps/api/priv/repo/migrations/20240101000001_create_job_postings.exs
@@ -1,0 +1,16 @@
+defmodule Dashboard.Repo.Migrations.CreateJobPostings do
+  use Ecto.Migration
+
+  def change do
+    create table(:job_postings, primary_key: false) do
+      add :id, :uuid, primary_key: true
+      add :title, :string, null: false
+      add :company, :string
+      add :url, :string, null: false
+      add :condition_id, references(:job_conditions, type: :uuid, on_delete: :delete_all), null: false
+      timestamps()
+    end
+
+    create index(:job_postings, [:condition_id])
+  end
+end

--- a/backend/apps/api/test/github_provider_test.exs
+++ b/backend/apps/api/test/github_provider_test.exs
@@ -1,0 +1,8 @@
+defmodule Dashboard.Jobs.GitHubProviderTest do
+  use ExUnit.Case
+
+  test "fetch returns at least one posting" do
+    results = Dashboard.Jobs.Providers.GitHub.fetch("elixir")
+    assert length(results) > 0
+  end
+end

--- a/backend/apps/api/test/test_helper.exs
+++ b/backend/apps/api/test/test_helper.exs
@@ -1,0 +1,2 @@
+ExUnit.start()
+Mox.defmock(Dashboard.Jobs.MockProvider, for: Dashboard.Jobs.Provider)

--- a/backend/config/config.exs
+++ b/backend/config/config.exs
@@ -1,0 +1,19 @@
+import Config
+
+config :api,
+  ecto_repos: [Dashboard.Repo],
+  generators: [binary_id: true]
+
+config :api, DashboardWeb.Endpoint,
+  url: [host: "localhost"],
+  render_errors: [view: DashboardWeb.ErrorView, accepts: ~w(json)],
+  pubsub_server: Dashboard.PubSub,
+  live_view: [signing_salt: "secret"]
+
+config :logger, :console,
+  format: "$time $metadata[$level] $message\n",
+  metadata: [:request_id]
+
+config :phoenix, :json_library, Jason
+
+import_config "#{config_env()}.exs"

--- a/backend/config/dev.exs
+++ b/backend/config/dev.exs
@@ -1,0 +1,14 @@
+import Config
+
+config :api, Dashboard.Repo,
+  database: "personal_dashboard_dev",
+  username: "postgres",
+  password: "postgres",
+  hostname: "localhost",
+  show_sensitive_data_on_connection_error: true,
+  pool_size: 10
+
+config :api, DashboardWeb.Endpoint,
+  http: [port: 4000],
+  code_reloader: true,
+  debug_errors: true

--- a/backend/config/prod.exs
+++ b/backend/config/prod.exs
@@ -1,0 +1,10 @@
+import Config
+
+config :api, Dashboard.Repo,
+  url: System.get_env("DATABASE_URL"),
+  pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
+  ssl: true
+
+config :api, DashboardWeb.Endpoint,
+  http: [:inet6, port: System.get_env("PORT") || 4000],
+  secret_key_base: System.fetch_env!("SECRET_KEY_BASE")

--- a/backend/config/runtime.exs
+++ b/backend/config/runtime.exs
@@ -1,0 +1,22 @@
+import Config
+
+database_url = System.get_env("DATABASE_URL") ||
+  "ecto://postgres:postgres@localhost/personal_dashboard_dev"
+
+config :api, Dashboard.Repo,
+  url: database_url,
+  pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
+  ssl: false
+
+config :api, DashboardWeb.Endpoint,
+  http: [ip: {0,0,0,0}, port: String.to_integer(System.get_env("PORT") || "4000")],
+  secret_key_base: System.get_env("SECRET_KEY_BASE") || "secret",
+  server: true
+
+config :api, Oban,
+  repo: Dashboard.Repo,
+  plugins: [{Oban.Plugins.Cron, crontab: [{"@hourly", Dashboard.Jobs.Cron}]}],
+  queues: [default: 10]
+
+config :dashboard, :github_jobs_endpoint,
+  System.get_env("GITHUB_JOBS_ENDPOINT") || "https://ghjobs.io/api/v1/jobs"

--- a/backend/config/test.exs
+++ b/backend/config/test.exs
@@ -1,0 +1,13 @@
+import Config
+
+config :api, Dashboard.Repo,
+  database: "personal_dashboard_test",
+  username: "postgres",
+  password: "postgres",
+  hostname: "localhost",
+  pool: Ecto.Adapters.SQL.Sandbox,
+  pool_size: 10
+
+config :api, DashboardWeb.Endpoint, server: false
+
+config :logger, level: :warning

--- a/backend/mix.exs
+++ b/backend/mix.exs
@@ -1,0 +1,15 @@
+defmodule PersonalDashboard.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      apps_path: "apps",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  defp deps do
+    []
+  end
+end

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Personal Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "personal-dashboard-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "graphql": "^16.8.0",
+    "@apollo/client": "^3.8.0",
+    "@tanstack/react-query": "^5.0.0",
+    "zustand": "^4.4.0"
+  },
+  "devDependencies": {
+    "vite": "^4.5.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.0.0",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0",
+    "vitest": "^0.34.0",
+    "@testing-library/react": "^14.0.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { Card } from './components/Card'
+import { JobFeed } from './components/JobFeed'
+
+export default function App() {
+  return (
+    <div className="min-h-screen bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+      <nav className="p-4 bg-gray-200 dark:bg-gray-800 mb-4">
+        <span className="font-bold">Welcome, user</span>
+      </nav>
+      <div className="max-w-2xl mx-auto p-4">
+        <Card>
+          <JobFeed conditionId="demo" />
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+export const Card: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div className="bg-white dark:bg-gray-800 shadow rounded p-4">
+    {children}
+  </div>
+)

--- a/frontend/src/components/JobFeed.tsx
+++ b/frontend/src/components/JobFeed.tsx
@@ -1,0 +1,62 @@
+import { gql, useApolloClient, useSubscription } from '@apollo/client'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+
+const JOBS = gql`
+  query($conditionId: ID!) {
+    job_postings(condition_id: $conditionId) {
+      id
+      title
+      company
+      url
+    }
+  }
+`
+
+const JOB_ADDED = gql`
+  subscription($conditionId: ID!) {
+    job_posting_added(condition_id: $conditionId) {
+      id
+      title
+      company
+      url
+    }
+  }
+`
+
+export function JobFeed({ conditionId }: { conditionId: string }) {
+  const client = useApolloClient()
+  const queryClient = useQueryClient()
+
+  const { data } = useQuery({
+    queryKey: ['jobs', conditionId],
+    queryFn: async () => {
+      const { data } = await client.query({ query: JOBS, variables: { conditionId } })
+      return data.job_postings
+    }
+  })
+
+  useSubscription(JOB_ADDED, {
+    variables: { conditionId },
+    onData: ({ data }) => {
+      const posting = data.data?.job_posting_added
+      if (posting) {
+        queryClient.setQueryData(['jobs', conditionId], (old: any = []) => [...old, posting])
+      }
+    }
+  })
+
+  if (!data) return <p>Loading...</p>
+
+  return (
+    <ul className="space-y-2">
+      {data.map((p: any) => (
+        <li key={p.id} className="border-b border-gray-700 pb-1">
+          <a href={p.url} className="underline" target="_blank" rel="noreferrer">
+            {p.title}
+          </a>
+          {p.company && <span className="text-sm text-gray-400"> - {p.company}</span>}
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,8 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --color-bg: #f8fafc;
+  --color-bg-dark: #1f2937;
+}

--- a/frontend/src/lib/apollo.ts
+++ b/frontend/src/lib/apollo.ts
@@ -1,0 +1,24 @@
+import { ApolloClient, InMemoryCache, HttpLink, split } from '@apollo/client'
+import { WebSocketLink } from '@apollo/client/link/ws'
+import { getMainDefinition } from '@apollo/client/utilities'
+
+const httpLink = new HttpLink({ uri: '/api/graphql' })
+
+const wsLink = new WebSocketLink({
+  uri: `ws://${window.location.host}/socket`,
+  options: { reconnect: true }
+})
+
+const splitLink = split(
+  ({ query }) => {
+    const definition = getMainDefinition(query)
+    return definition.kind === 'OperationDefinition' && definition.operation === 'subscription'
+  },
+  wsLink,
+  httpLink
+)
+
+export const client = new ApolloClient({
+  link: splitLink,
+  cache: new InMemoryCache()
+})

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { ApolloProvider } from '@apollo/client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { client } from './lib/apollo'
+import App from './App'
+import './index.css'
+
+const queryClient = new QueryClient()
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <ApolloProvider client={client}>
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
+    </ApolloProvider>
+  </React.StrictMode>
+)

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+}

--- a/frontend/test/jobfeed.test.tsx
+++ b/frontend/test/jobfeed.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ApolloProvider } from '@apollo/client'
+import { client } from '../src/lib/apollo'
+import { JobFeed } from '../src/components/JobFeed'
+
+const queryClient = new QueryClient()
+
+describe('JobFeed', () => {
+  it('renders without crashing', () => {
+    render(
+      <ApolloProvider client={client}>
+        <QueryClientProvider client={queryClient}>
+          <JobFeed conditionId="demo" />
+        </QueryClientProvider>
+      </ApolloProvider>
+    )
+  })
+})

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom'
+  }
+})


### PR DESCRIPTION
## Summary
- set up Phoenix umbrella in `backend/`
- add Absinthe GraphQL endpoint with Oban cron worker
- implement GitHub jobs provider
- create Vite/React frontend with Tailwind dark theme
- provide root Makefile for dev workflow

## Testing
- `make test` *(fails: mix not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d69869d0483319bf8b7efae8b53ac