### PR TITLE
Fix hex dependency mismatch

### DIFF
--- a/backend/apps/api/mix.exs
+++ b/backend/apps/api/mix.exs
@@ -30,7 +30,7 @@ defmodule Api.MixProject do
       {:ecto_sql, "~> 3.10"},
       {:postgrex, ">= 0.0.0"},
       {:absinthe, "~> 1.7"},
-      {:absinthe_plug, "~> 1.7"},
+      {:absinthe_plug, "~> 1.5"},
       {:oban, "~> 2.17"},
       {:finch, "~> 0.16"},
       {:jason, "~> 1.4"},


### PR DESCRIPTION
## Summary
- use valid `absinthe_plug` version

## Testing
- `make test` *(fails: `mix` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d6bf977908331bd8d66f079a50391