### PR TITLE
Fix GraphQL schema type

### DIFF
--- a/backend/apps/api/lib/dashboard_web/schema.ex
+++ b/backend/apps/api/lib/dashboard_web/schema.ex
@@ -1,5 +1,6 @@
 defmodule DashboardWeb.Schema do
   use Absinthe.Schema
+  import_types Absinthe.Type.Custom
   alias Dashboard.Jobs
 
   object :job_posting do


### PR DESCRIPTION
## Summary
- import Absinthe.Type.Custom so :naive_datetime is defined

## Testing
- `make test` *(fails: mix not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d6d4f17e48331873de4c8a3b00fb2