### PR TITLE
Fix Gettext compile error

### DIFF
--- a/backend/apps/api/mix.exs
+++ b/backend/apps/api/mix.exs
@@ -18,7 +18,7 @@ defmodule Api.MixProject do
   def application do
     [
       mod: {Dashboard.Application, []},
-      extra_applications: [:logger, :runtime_tools]
+      extra_applications: [:logger, :runtime_tools, :gettext]
     ]
   end
 
@@ -29,6 +29,7 @@ defmodule Api.MixProject do
       {:phoenix_ecto, "~> 4.4"},
       {:ecto_sql, "~> 3.10"},
       {:postgrex, ">= 0.0.0"},
+      {:gettext, "~> 0.20"},
       {:absinthe, "~> 1.7"},
       {:absinthe_plug, "~> 1.5"},
       {:oban, "~> 2.17"},


### PR DESCRIPTION
## Summary
- add `:gettext` to applications and dependencies

## Testing
- `make setup` *(fails: `mix` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d6e7d77c88331a05ab753589b1ef4