### PR TITLE
Fix misnamed dashboard config

### DIFF
--- a/backend/apps/api/lib/dashboard/jobs/context.ex
+++ b/backend/apps/api/lib/dashboard/jobs/context.ex
@@ -28,6 +28,6 @@ defmodule Dashboard.Jobs do
   end
 
   defp provider do
-    Application.get_env(:dashboard, :provider, Dashboard.Jobs.Providers.GitHub)
+    Application.get_env(:api, :provider, Dashboard.Jobs.Providers.GitHub)
   end
 end

--- a/backend/apps/api/lib/dashboard/jobs/providers/github.ex
+++ b/backend/apps/api/lib/dashboard/jobs/providers/github.ex
@@ -2,7 +2,7 @@ defmodule Dashboard.Jobs.Providers.GitHub do
   @behaviour Dashboard.Jobs.Provider
   require Logger
 
-  @endpoint Application.compile_env(:dashboard, :github_jobs_endpoint, "https://ghjobs.io/api/v1/jobs")
+  @endpoint Application.compile_env(:api, :github_jobs_endpoint, "https://ghjobs.io/api/v1/jobs")
 
   def fetch(keyword) do
     url = "#{@endpoint}?search=#{URI.encode(keyword)}"

--- a/backend/config/runtime.exs
+++ b/backend/config/runtime.exs
@@ -18,5 +18,5 @@ config :api, Oban,
   plugins: [{Oban.Plugins.Cron, crontab: [{"@hourly", Dashboard.Jobs.Cron}]}],
   queues: [default: 10]
 
-config :dashboard, :github_jobs_endpoint,
+config :api, :github_jobs_endpoint,
   System.get_env("GITHUB_JOBS_ENDPOINT") || "https://ghjobs.io/api/v1/jobs"


### PR DESCRIPTION
## Summary
- reference the existing `:api` application when configuring GitHub jobs
- use `:api` when reading provider configuration at runtime
- use `:api` for compile‑time GitHub endpoint configuration

## Testing
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d6f4a6a908331917fb5b7827a05fb