### PR TITLE
Add Absinthe.Phoenix to API dependencies

### DIFF
--- a/backend/apps/api/mix.exs
+++ b/backend/apps/api/mix.exs
@@ -32,6 +32,7 @@ defmodule Api.MixProject do
       {:gettext, "~> 0.20"},
       {:absinthe, "~> 1.7"},
       {:absinthe_plug, "~> 1.5"},
+      {:absinthe_phoenix, "~> 2.0"},
       {:oban, "~> 2.17"},
       {:finch, "~> 0.16"},
       {:jason, "~> 1.4"},


### PR DESCRIPTION
## Summary
- include `absinthe_phoenix` dependency so the GraphQL socket child spec exists

## Testing
- `mix test` *(fails: `mix` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d76047d6483319faf8b3446ee4569