### PR TITLE
Fix warnings and add Oban migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # pdboard
+
+This repository contains a simple Elixir/Phoenix API and a separate frontend.
+
+## Setup
+
+From the project root run:
+
+```bash
+mix deps.get
+mix ecto.setup
+```
+
+The `ecto.setup` task will create the database and run all migrations,
+including the one that creates Oban's tables.
+
+To start the API server run:
+
+```bash
+cd backend && mix phx.server
+```
+
+## Testing
+
+Execute tests from the `backend` directory:
+
+```bash
+mix test
+```

--- a/backend/apps/api/lib/dashboard/jobs/context.ex
+++ b/backend/apps/api/lib/dashboard/jobs/context.ex
@@ -1,7 +1,7 @@
 defmodule Dashboard.Jobs do
-  alias Dashboard.{Repo, Jobs}
+  alias Dashboard.Repo
   import Ecto.Query
-  alias Dashboard.Jobs.{JobPosting, JobCondition, Provider}
+  alias Dashboard.Jobs.{JobPosting, JobCondition}
 
   def list_conditions do
     Repo.all(JobCondition)

--- a/backend/apps/api/lib/dashboard_web.ex
+++ b/backend/apps/api/lib/dashboard_web.ex
@@ -3,7 +3,7 @@ defmodule DashboardWeb do
     quote do
       use Phoenix.Controller, namespace: DashboardWeb
       import Plug.Conn
-      import DashboardWeb.Gettext
+      use Gettext, backend: DashboardWeb.Gettext
     end
   end
 
@@ -42,7 +42,7 @@ defmodule DashboardWeb do
 
   def gettext do
     quote do
-      import DashboardWeb.Gettext
+      use Gettext, backend: DashboardWeb.Gettext
     end
   end
 

--- a/backend/apps/api/lib/dashboard_web/gettext.ex
+++ b/backend/apps/api/lib/dashboard_web/gettext.ex
@@ -1,3 +1,3 @@
 defmodule DashboardWeb.Gettext do
-  use Gettext, otp_app: :api
+  use Gettext.Backend, otp_app: :api
 end

--- a/backend/apps/api/priv/repo/migrations/20240101000002_add_oban_tables.exs
+++ b/backend/apps/api/priv/repo/migrations/20240101000002_add_oban_tables.exs
@@ -1,0 +1,11 @@
+defmodule Dashboard.Repo.Migrations.AddObanTables do
+  use Ecto.Migration
+
+  def up do
+    Oban.Migrations.up(version: 11)
+  end
+
+  def down do
+    Oban.Migrations.down(version: 0)
+  end
+end


### PR DESCRIPTION
## Summary
- clean up unused aliases in `Dashboard.Jobs`
- update Gettext setup to new recommended API
- use the new Gettext backend in `DashboardWeb`
- add Oban migrations
- expand README with setup instructions

## Testing
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d7811cc0c8331bde58e369636f405