### PR TITLE
Add dev-all target to run API and frontend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,11 @@ db.reset:
 dev:
 	cd backend && mix phx.server
 
+dev-all:
+	cd backend && mix phx.server & \
+	cd frontend && npm run dev & \
+	wait
+
 test:
 	cd backend && mix test
 	cd frontend && npm test -- --run

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ To start the API server run:
 cd backend && mix phx.server
 ```
 
+To run the API and frontend together during development, use the Makefile:
+
+```bash
+make dev-all
+```
+
 ## Testing
 
 Execute tests from the `backend` directory:


### PR DESCRIPTION
## Summary
- add `dev-all` target in Makefile to start backend and frontend concurrently
- document usage in README

## Testing
- `grep -nP '^\t' Makefile`


------
https://chatgpt.com/codex/tasks/task_e_685d7ec06f78833185ab8e63aeccf5b1