### PR TITLE
Fix frontend missing dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "react-dom": "^18.2.0",
     "graphql": "^16.8.0",
     "@apollo/client": "^3.8.0",
+    "subscriptions-transport-ws": "^0.11.0",
     "@tanstack/react-query": "^5.0.0",
     "zustand": "^4.4.0"
   },


### PR DESCRIPTION
## Summary
- add `subscriptions-transport-ws` to frontend deps

## Testing
- `make test` *(fails: mix not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d81aeaa748331b850ed0d07110635