### PR TITLE
Fix runtime config overriding dev settings

### DIFF
--- a/backend/config/runtime.exs
+++ b/backend/config/runtime.exs
@@ -1,17 +1,19 @@
 import Config
 
-database_url = System.get_env("DATABASE_URL") ||
-  "ecto://dashboard:abc123@localhost:5432/dashboard_dev"
+if config_env() == :prod do
+  database_url = System.get_env("DATABASE_URL") ||
+    "ecto://dashboard:abc123@localhost:5432/dashboard_prod"
 
-config :api, Dashboard.Repo,
-  url: database_url,
-  pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
-  ssl: false
+  config :api, Dashboard.Repo,
+    url: database_url,
+    pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
+    ssl: false
 
-config :api, DashboardWeb.Endpoint,
-  http: [ip: {0,0,0,0}, port: String.to_integer(System.get_env("PORT") || "4000")],
-  secret_key_base: System.get_env("SECRET_KEY_BASE") || "secret",
-  server: true
+  config :api, DashboardWeb.Endpoint,
+    http: [ip: {0,0,0,0}, port: String.to_integer(System.get_env("PORT") || "4000")],
+    secret_key_base: System.get_env("SECRET_KEY_BASE") || "secret",
+    server: true
+end
 
 config :api, Oban,
   repo: Dashboard.Repo,


### PR DESCRIPTION
## Summary
- prevent runtime.exs from overriding development configs

## Testing
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d9574517c833180facc0742e7f7cc