### PR TITLE
Integrate design system side navbar

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,18 +1,22 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Card } from './components/Card'
 import { JobFeed } from './components/JobFeed'
+import { SideNavbar } from './components/SideNavbar'
+import { init } from '@design-system/src/js/init.js'
 
 export default function App() {
+  useEffect(() => {
+    init()
+  }, [])
+
   return (
-    <div className="min-h-screen bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
-      <nav className="p-4 bg-gray-200 dark:bg-gray-800 mb-4">
-        <span className="font-bold">Welcome, user</span>
-      </nav>
-      <div className="max-w-2xl mx-auto p-4">
+    <div style={{ display: 'flex', minHeight: '100vh' }}>
+      <SideNavbar />
+      <main style={{ padding: 'var(--space-lg)', flex: 1 }}>
         <Card>
           <JobFeed conditionId="demo" />
         </Card>
-      </div>
+      </main>
     </div>
   )
 }

--- a/frontend/src/components/SideNavbar.tsx
+++ b/frontend/src/components/SideNavbar.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+export const SideNavbar: React.FC = () => (
+  <aside className="sidebar" aria-expanded="true">
+    <button className="sidebar__toggle" data-sidebar-toggle>☰</button>
+    <ul className="sidebar__nav">
+      <li className="sidebar__item sidebar__item--active">Home</li>
+      <li className="sidebar__item">Link</li>
+    </ul>
+  </aside>
+)
+

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import { ApolloProvider } from '@apollo/client'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { client } from './lib/apollo'
 import App from './App'
+import '@design-system/design-system.css'
 import './index.scss'
 
 const queryClient = new QueryClient()

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,8 +1,19 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { resolve } from 'path'
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@design-system': resolve(__dirname, '..', 'design-system')
+    }
+  },
+  server: {
+    fs: {
+      allow: ['..']
+    }
+  },
   test: {
     environment: 'jsdom'
   }


### PR DESCRIPTION
## Summary
- import design system assets via Vite alias
- include design system CSS in the React entry
- initialize the design system when the app mounts
- add a SideNavbar component and use it in the layout

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d99004834833191157f6df57d95b8